### PR TITLE
Fix Message.sendRaw

### DIFF
--- a/lib/models/message.js
+++ b/lib/models/message.js
@@ -184,7 +184,7 @@
       return nylasConnection.request(opts).then((function(_this) {
         return function(json) {
           var msg;
-          msg = new Message(_this, json);
+          msg = new Message(nylasConnection, json);
           if (callback) {
             callback(null, msg);
           }

--- a/models/message.coffee
+++ b/models/message.coffee
@@ -144,7 +144,7 @@ class Message extends RestfulModel
 
     nylasConnection.request opts
     .then (json) =>
-      msg = new Message(@, json)
+      msg = new Message(nylasConnection, json)
       callback(null, msg) if callback
       Promise.resolve(msg)
     .catch (err) ->


### PR DESCRIPTION
Before this change, `Message.sendRaw` would always throw an error after
a successful send, which is the worse time for an email sending client
to respond with an error. The issue is a coding error.

To fix,
* Pass `nylasConnection` as the first parameter to the `Message`
  constructor when creating a message object after a successful send.