### PR TITLE
Log more information when nylas has a request error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _SpecRunner.html
 *.swo
 tags
 CTAGS
+.idea

--- a/lib/nylas-connection.js
+++ b/lib/nylas-connection.js
@@ -137,7 +137,10 @@
   })();
 
   logOnError = function(error, response, body) {
-    console.log('nylas-connection#request error: ', JSON.stringify(error));
+    console.log('nylas-connection#request error: ', error.toString());
+    if (error.stack) {
+      console.log('nylas-connection#request stack: ', error.stack);
+    }
     if (response) {
       console.log('nylas-connection#request response.statusCode: ', response.statusCode);
       console.log('nylas-connection#request response.statusMessage: ', response.statusMessage);

--- a/lib/nylas-connection.js
+++ b/lib/nylas-connection.js
@@ -1,5 +1,5 @@
 (function() {
-  var Account, Attributes, Calendar, Contact, Delta, Draft, Event, File, Folder, Label, ManagementAccount, ManagementModelCollection, Message, NylasConnection, Promise, RestfulModel, RestfulModelCollection, RestfulModelInstance, Tag, Thread, _, clone, request;
+  var Account, Attributes, Calendar, Contact, Delta, Draft, Event, File, Folder, Label, ManagementAccount, ManagementModelCollection, Message, NylasConnection, Promise, RestfulModel, RestfulModelCollection, RestfulModelInstance, Tag, Thread, _, clone, logOnError, request;
 
   _ = require('underscore');
 
@@ -110,6 +110,7 @@
             if (error == null) {
               error = new Error(body.message);
             }
+            logOnError(error, response, body);
             return reject(error);
           } else {
             if (options.downloadRequest) {
@@ -122,6 +123,7 @@
                 return resolve(body);
               } catch (_error) {
                 error = _error;
+                logOnError(error, response, body);
                 return reject(error);
               }
             }
@@ -133,5 +135,16 @@
     return NylasConnection;
 
   })();
+
+  logOnError = function(error, response, body) {
+    console.log('nylas-connection#request error: ', JSON.stringify(error));
+    if (response) {
+      console.log('nylas-connection#request response.statusCode: ', response.statusCode);
+      console.log('nylas-connection#request response.statusMessage: ', response.statusMessage);
+    }
+    if (body) {
+      return console.log('nylas-connection#request body', body);
+    }
+  };
 
 }).call(this);

--- a/lib/nylas.js
+++ b/lib/nylas.js
@@ -102,6 +102,7 @@
     };
 
     Nylas.urlForAuthentication = function(options) {
+      var url;
       if (options == null) {
         options = {};
       }
@@ -117,9 +118,9 @@
       if (options.trial == null) {
         options.trial = false;
       }
-      var url = this.apiServer + "/oauth/authorize?client_id=" + this.appId + "&trial=" + options.trial + "&response_type=code&scope=email&login_hint=" + options.loginHint + "&redirect_uri=" + options.redirectURI;
+      url = this.apiServer + "/oauth/authorize?client_id=" + this.appId + "&trial=" + options.trial + "&response_type=code&scope=email&login_hint=" + options.loginHint + "&redirect_uri=" + options.redirectURI;
       if (options.state != null) {
-        url += '&state=' + options.state;
+        url += "&state=" + options.state;
       }
       return url;
     };

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -80,7 +80,10 @@ class NylasConnection
 
 
 logOnError = (error, response, body) ->
-  console.log('nylas-connection#request error: ', JSON.stringify(error))
+  console.log('nylas-connection#request error: ', error.toString())
+
+  if error.stack
+    console.log('nylas-connection#request stack: ', error.stack)
 
   if response
     console.log('nylas-connection#request response.statusCode: ', response.statusCode)

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -65,6 +65,7 @@ class NylasConnection
       request options, (error, response, body) ->
         if error or response.statusCode > 299
           error ?= new Error(body.message)
+          logOnError(error, response, body)
           reject(error)
         else
           if options.downloadRequest
@@ -74,4 +75,16 @@ class NylasConnection
               body = JSON.parse(body) if _.isString body
               resolve(body)
             catch error
+              logOnError(error, response, body)
               reject(error)
+
+
+logOnError = (error, response, body) ->
+  console.log('nylas-connection#request error: ', JSON.stringify(error))
+
+  if response
+    console.log('nylas-connection#request response.statusCode: ', response.statusCode)
+    console.log('nylas-connection#request response.statusMessage: ', response.statusMessage)
+
+  if body
+    console.log('nylas-connection#request body', body)

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -82,6 +82,9 @@ class NylasConnection
 logOnError = (error, response, body) ->
   console.log('nylas-connection#request error: ', error.toString())
 
+  if error.code?
+    console.log('nylas-connection#request error.code: ', error.code)
+
   if error.stack
     console.log('nylas-connection#request stack: ', error.stack)
 


### PR DESCRIPTION
This ensures we log out the full error object, the status code and
message, and the full response body when there is an error in the
`NylasConnection#request` method. This is to work around a bug where we
are only getting a non-descript error from the nylas api, and we need
more information to suss out.