### PR TITLE
Fix connection error handling to provide more info

### DIFF
--- a/lib/nylas-connection.js
+++ b/lib/nylas-connection.js
@@ -106,9 +106,23 @@
       options = this.requestOptions(options);
       return new Promise(function(resolve, reject) {
         return request(options, function(error, response, body) {
+          var e;
+          try {
+            if (_.isString(body)) {
+              body = JSON.parse(body);
+            }
+          } catch (_error) {
+            e = _error;
+            if (!error) {
+              error = e;
+            }
+          }
           if (error || response.statusCode > 299) {
             if (error == null) {
               error = new Error(body.message);
+            }
+            if (body.type) {
+              error.code = body.type;
             }
             logOnError(error, response, body);
             return reject(error);
@@ -116,16 +130,7 @@
             if (options.downloadRequest) {
               return resolve(response);
             } else {
-              try {
-                if (_.isString(body)) {
-                  body = JSON.parse(body);
-                }
-                return resolve(body);
-              } catch (_error) {
-                error = _error;
-                logOnError(error, response, body);
-                return reject(error);
-              }
+              return resolve(body);
             }
           }
         });
@@ -138,6 +143,9 @@
 
   logOnError = function(error, response, body) {
     console.log('nylas-connection#request error: ', error.toString());
+    if (error.code != null) {
+      console.log('nylas-connection#request error.code: ', error.code);
+    }
     if (error.stack) {
       console.log('nylas-connection#request stack: ', error.stack);
     }

--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -63,21 +63,21 @@ class NylasConnection
 
     new Promise (resolve, reject) ->
       request options, (error, response, body) ->
+        try
+          body = JSON.parse(body) if _.isString body
+        catch e
+          error = e unless error
+
         if error or response.statusCode > 299
           error ?= new Error(body.message)
+          error.code = body.type if body.type
           logOnError(error, response, body)
           reject(error)
         else
           if options.downloadRequest
             return resolve(response)
           else
-            try
-              body = JSON.parse(body) if _.isString body
-              resolve(body)
-            catch error
-              logOnError(error, response, body)
-              reject(error)
-
+            resolve(body)
 
 logOnError = (error, response, body) ->
   console.log('nylas-connection#request error: ', error.toString())


### PR DESCRIPTION
## Changes
- Where the error was using `body.message`, the `body` was still stringified JSON instead of an object, so we never actually got the error message for these errors.