### PR TITLE
Check if body exists in nylas-connection error handling

### DIFF
--- a/nylas-connection.coffee
+++ b/nylas-connection.coffee
@@ -70,12 +70,12 @@ class NylasConnection
 
         if error or response.statusCode > 299
           unless error
-            if _.isString(body.message)
-              error = new Error(body.message)
+            if _.isString(body?.message)
+              error = new Error(body?.message)
             else
-              error = new Error(JSON.stringify(body.message))
-          error.code = body.type if body.type
-          error.server_error = body.server_error if body.server_error
+              error = new Error(JSON.stringify(body?.message))
+          error.code = body.type if body?.type
+          error.server_error = body.server_error if body?.server_error
           logOnError(error, response, body)
           reject(error)
         else


### PR DESCRIPTION
Some errors come back from nylas without a body, in which case this original code throws an error when we're trying to get its type.

We should be okay with this going forward because `logOnError` checks correctly if there's a body, and then the error is rejected.