### PR TITLE
adding catch chain to handle thrown errors

### DIFF
--- a/lib/models/restful-model-collection.js
+++ b/lib/models/restful-model-collection.js
@@ -168,6 +168,11 @@
               accumulated = accumulated.concat(models);
               finished = models.length < REQUEST_CHUNK_SIZE || accumulated.length >= limit;
               return chunkCallback();
+            }).catch(function(error) {
+              if (callback) {
+                callback(err);
+              }
+              return reject(error);
             });
           }, function(err) {
             if (err) {

--- a/lib/models/restful-model-collection.js
+++ b/lib/models/restful-model-collection.js
@@ -168,12 +168,7 @@
               accumulated = accumulated.concat(models);
               finished = models.length < REQUEST_CHUNK_SIZE || accumulated.length >= limit;
               return chunkCallback();
-            }).catch(function(error) {
-              if (callback) {
-                callback(err);
-              }
-              return reject(error);
-            });
+            }).catch(chunkCallback);
           }, function(err) {
             if (err) {
               if (callback) {

--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -77,10 +77,17 @@ class RestfulModelCollection
       , (chunkCallback) =>
         chunkOffset = offset + accumulated.length
         chunkLimit = Math.min(REQUEST_CHUNK_SIZE, limit - accumulated.length)
-        @getModelCollection(params, chunkOffset, chunkLimit).then (models) ->
-          accumulated = accumulated.concat(models)
-          finished = models.length < REQUEST_CHUNK_SIZE or accumulated.length >= limit
-          chunkCallback()
+        @getModelCollection(params, chunkOffset, chunkLimit)
+          .then((models) ->
+            accumulated = accumulated.concat(models)
+            finished = models.length < REQUEST_CHUNK_SIZE or accumulated.length >= limit
+            chunkCallback()
+          )
+          .catch((err) ->
+            if err
+              callback(err) if callback
+              reject(err)
+          )
       , (err) ->
         if err
           callback(err) if callback

--- a/models/restful-model-collection.coffee
+++ b/models/restful-model-collection.coffee
@@ -83,11 +83,7 @@ class RestfulModelCollection
             finished = models.length < REQUEST_CHUNK_SIZE or accumulated.length >= limit
             chunkCallback()
           )
-          .catch((err) ->
-            if err
-              callback(err) if callback
-              reject(err)
-          )
+          .catch(chunkCallback)
       , (err) ->
         if err
           callback(err) if callback


### PR DESCRIPTION
adding this catch method here adds another safe guard against unhandled rejections. after running the `dev.coffee` file in the `test/reproduce-unhandled-rejection` branch,  we are now successfully handling promise rejections.

moving forward, i tried to reproduce this logic and behavior locally with `hire2` > `taskqueue2` > `suite` > `lever-nylas` and even **without** this logic, it seems like we're successfully swallowing errors. perhaps there is something happening in production in addition to this. regardless, it's great that we have another safety net in place after this one.

when we roll out this change, we can see if the errors are showing up in bugsnag, and if not, we'll know we've successfully addressed a portion of these issues!